### PR TITLE
Refactor gh auth to use deploy key instead of token

### DIFF
--- a/charts/bootstrap-argo/templates/secret.yaml
+++ b/charts/bootstrap-argo/templates/secret.yaml
@@ -6,6 +6,5 @@ metadata:
     argocd.argoproj.io/secret-type: repository
 stringData:
   type: git
-  url: {{ .Values.source.repoUrl }}
-  username: {{ .Values.source.username }}
-  password: {{ .Values.source.password }}
+  url: {{ .Values.source.repoURL }}
+  sshPrivateKey: {{ .Values.source.sshPrivateKey | quote }}

--- a/charts/bootstrap-argo/values.yaml
+++ b/charts/bootstrap-argo/values.yaml
@@ -7,8 +7,7 @@ source:
   repoURL: my-deployment-repo
   targetRevision: main
   secretName: lab-cluster-repo
-  username: git
-  password: s3cr3t
+  sshPrivateKey: ""
 autosync:
   enabled: false
 secretStore:

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -23,7 +23,7 @@ DOMAIN=""
 SECRET_STORE_BACKEND="kubernetes"
 
 # Constants, cannot be set via flags or environment variables
-REPO_URL=https://github.com/joerx/lab-cluster.sh.git
+REPO_URL=git@github.com:joerx/lab-cluster.sh.git
 ARGO_NAMESPACE="argocd"
 ARGO_CHART_VERSION="9.4.7"
 EXTERNAL_SECRETS_NAMESPACE="external-secrets"
@@ -185,8 +185,7 @@ helm upgrade --install bootstrap-argo ./charts/bootstrap-argo \
   --set "externalDNS.enabled=$EXTERNAL_DNS_ENABLED" \
   --set "source.repoURL=$REPO_URL" \
   --set "source.targetRevision=$TARGET_REVISION" \
-  --set "source.username=joerx" \
-  --set "source.password=$GITHUB_TOKEN" \
+  --set-file "source.sshPrivateKey=$KEY_FILE" \
   --set "autosync.enabled=$AUTO_SYNC" \
   --set "secretStore.backend=$SECRET_STORE_BACKEND" \
   --set "infisical.project=$INFISICAL_PROJECT" \


### PR DESCRIPTION
Deploy keys can be scoped per repo and don't expire. They can also be provisioned with Terraform via [repository_deploy_key](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository_deploy_key) while tokens need to be handled manually. 

This PR switches the auth mechanism for the GitHub deploy key to SSH auth. By default the users local `"$HOME/.ssh/id_ed25519"` is used, this can be configured as before via the `--ssh-key` flag.