### PR TITLE
Set memory limit for servers

### DIFF
--- a/scripts/providers/k3d/create.sh
+++ b/scripts/providers/k3d/create.sh
@@ -2,6 +2,8 @@
 
 set -euo pipefail
 
+MEMORY_LIMIT=12GB
+
 log() {
   >&2 echo "$@"
 }
@@ -27,6 +29,7 @@ k3d cluster create $NAME\
   --api-port 6550 \
   -p "8080:80@loadbalancer" \
   -p "8443:443@loadbalancer" \
+  --servers-memory "${MEMORY_LIMIT}" \
   --k3s-arg "--disable=traefik@server:0"
 
 kubectl wait --for=condition=Ready nodes --all --timeout=120s


### PR DESCRIPTION
Default, at least on macOS seems to be 2GB which is not enough to run the lab cluster control plane. Experimenting with the correct settings in a constrained environment, so this is wip for now
