### PR TITLE
Integrate letsencrypt

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,12 +113,12 @@ Without `--auto-sync`, this will only install ArgoCD and sync the initial ArgoCD
 
 ### Cloud Based Deployment
 
-To bootstrap a cluster into the cloud, only LKE is currently supported.[^3] It is up to the user to decide how to obtain a cluster in the first place and usually requires additional infra to be in place. It also requires a [secrets management](#external-secrets) backend.
+To bootstrap a cluster into the cloud, only LKE is currently tested, although this should in principle also work with other managed clusters. It is up to the user to decide how to obtain a cluster in the first place and usually requires additional infrastructure. 
 
-To bootstrap with an existing secrets backend `my-cluster-l4b` and enable external DNS:
+This repo has been tested for [zuse-cc/terraform-linode-lke-cluster](https://github.com/zuse-cc/terraform-linode-lke-cluster/), a matching Terraform version of this bootstrap script can be found [here](https://github.com/zuse-cc/terraform-helm-cluster-bootstrap)
 
 ```sh
-./scripts/bootstrap.sh --auto-sync --name my-cluster-l4b --domain my-cluster-l4b.dev.example.com --external-dns
+./scripts/bootstrap.sh --auto-sync --domain my-cluster-l4b.dev.example.com --external-dns
 ```
 
 ### Validation
@@ -194,10 +194,11 @@ Secrets will be expected to reside under `/path/<cluster-name`, use `--name` to 
 
 ### External DNS
 
-External DNS is supported for [Linode DNS Manager](https://techdocs.akamai.com/cloud-computing/docs/dns-manager) for now. Requires a valid LINODE_TOKEN stored in the external secrets store. See [External Secrets](#external-secrets). 
+External DNS is supported for [Linode DNS Manager](https://techdocs.akamai.com/cloud-computing/docs/dns-manager) for now. Requires an existing Linode domain and a valid `LINODE_TOKEN`. The token can be either in an external secrets store or on the local shell environment. See [External Secrets](#external-secrets) 
 
 ```sh
-./scripts/bootstrap.sh $(hostname)-k3d-lab --auto-sync --name some-cloud-cluster --external-dns
+export LINODE_TOKEN=<your linode token> # Or use .env
+./scripts/bootstrap.sh --auto-sync --external-dns --domain your-domain.example.com
 ```
 
 ### Ngrok Ingress Controller
@@ -233,5 +234,3 @@ To periodically clean dangling endpoints (NB: This will delete ALL registered op
 [^1]: Doing so would leak problematic behaviour of a 3rd party operator into our toolchain and create complex, brittle code to maintain. The long-term maintenance drag is ultimately not worth the short term convenience gained.
 
 [^2]: Haven't found a way to label or tag the remote resources in any predictable way yet, so for now make sure to use a dedicated account for dev
-
-[^3]: Howewer, this should in principle also work with other cloud based clusters.

--- a/README.md
+++ b/README.md
@@ -80,8 +80,8 @@ Destroy VM (Will delete all data):
 ### Cloud Based Clusters
 
 - This tool is not designed to create cloud based clusters since there is too much variety between them
-- The [bootstrapping](#bootstrapping) components however are still designed to work on a managed cluster
-- So far I tested this only for [Linode LKE](https://techdocs.akamai.com/cloud-computing/docs/linode-kubernetes-engine) however
+- The [bootstrapping](#bootstrapping) components however are still intended to work on managed cluster by major providers
+- So far I tested this only for [Linode LKE](https://techdocs.akamai.com/cloud-computing/docs/linode-kubernetes-engine)
 - See [cloud cluster bootstrap](#cloud-based-deployment) for instructions how to bootstrap an LKE cluster
 
 ## Bootstrapping
@@ -154,27 +154,26 @@ kubectl -n argocd port-forward services/argocd-server 8444:https
 
 Open browser at [localhost:8444](https://localhost:8444), accept certificate error, log in with username 'admin' & password
 
-## Additional Options
-
-To set `--kubecfg` to the kubernetes config file created as part of cluster creation:
-
-```sh
-./scripts/bootstrap.sh --kubecfg $PWD/vms/k3s-lab/.kubecfg --auto-sync
-```
-
-To use the default `KUBECONFIG` but explicitly select a context:
-
-```sh
-./scripts/bootstrap.sh --context k3d-k3s-default --auto-sync
-```
-
-To deploy a specific branch or tag instead of `main`:
-
-```sh
-./scripts/bootstrap.sh --version my-working-branch
-```
-
 ## Components
+
+### Certificate Manager
+
+The default `cert-manager` configuration uses a local, self signed root CA for all certificate requests in the cluster. LetsEncrypt is supported when [external dns](#external-dns) is enabled too. In that case a `--domain` and `--letsencrypt-email` need to be passed to the bootstrap script and a `LINODE_TOKEN` is required:
+
+```sh
+export LINODE_TOKEN=<your linode token> # Or use .env
+./scripts/bootstrap.sh --auto-sync --external-dns --domain cluster.example.com --letsencrypt-email hostmaster@cluster.example.com
+```
+
+Cert manager will be using the `dns01` challenge so issuance of certificates can take a few minutes. Check the Linode console for the correct TXT records are being set in the clusters DNS zone. In the meantime, the Ingress controllers default dummy certificate will be shown.
+
+To validate a certificate on a local cluster:
+
+```sh
+HOST=$(kubectl get ingress hello-world -n default -o jsonpath='{.spec.rules[*].host}')
+IP=$(kubectl get ingress hello-world -n default -o jsonpath='{.status.loadBalancer.ingress[*].ip}')
+openssl s_client -connect $IP:443 -servername $HOST | openssl x509 -text -noout | grep Issuer
+```
 
 ### External Secrets
 
@@ -231,6 +230,27 @@ To periodically clean dangling endpoints (NB: This will delete ALL registered op
 ./scripts/misc/ngrok-cleanup.sh
 ```
 
+## Additional Options
+
+To set `--kubecfg` to the kubernetes config file created as part of cluster creation:
+
+```sh
+./scripts/bootstrap.sh --kubecfg $PWD/vms/k3s-lab/.kubecfg --auto-sync
+```
+
+To use the default `KUBECONFIG` but explicitly select a context:
+
+```sh
+./scripts/bootstrap.sh --context k3d-k3s-default --auto-sync
+```
+
+To deploy a specific branch or tag instead of `main`:
+
+```sh
+./scripts/bootstrap.sh --version my-working-branch
+```
+
 [^1]: Doing so would leak problematic behaviour of a 3rd party operator into our toolchain and create complex, brittle code to maintain. The long-term maintenance drag is ultimately not worth the short term convenience gained.
 
 [^2]: Haven't found a way to label or tag the remote resources in any predictable way yet, so for now make sure to use a dedicated account for dev
+

--- a/bootstrap/templates/cert-manager-webhook-linode.yaml
+++ b/bootstrap/templates/cert-manager-webhook-linode.yaml
@@ -1,23 +1,17 @@
+{{- if .Values.letsencrypt.enabled }}
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: cluster-ca
+  name: cert-manager-webhook-linode
   namespace: argocd
   annotations:
-    argocd.argoproj.io/sync-wave: "2"
+    argocd.argoproj.io/sync-wave: "1"
 spec:
   project: bootstrap
   source:
     repoURL: '{{ .Values.source.repoURL }}'
     targetRevision: '{{ .Values.source.targetRevision }}'
-    path: manifests/cluster-ca
-    helm:
-      valuesObject:
-        cluster:
-          domain: '{{ .Values.cluster.domain }}'
-        letsencrypt:
-          enabled: {{ .Values.letsencrypt.enabled }}
-          email: '{{ .Values.letsencrypt.email }}'
+    path: charts/cert-manager-webhook-linode
   destination:
     server: "https://kubernetes.default.svc"
     namespace: cert-manager
@@ -28,3 +22,4 @@ spec:
     {{- end }}
     syncOptions:
       - CreateNamespace=true
+{{- end }}

--- a/bootstrap/templates/cert-manager.yaml
+++ b/bootstrap/templates/cert-manager.yaml
@@ -3,6 +3,8 @@ kind: Application
 metadata:
   name: cert-manager
   namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
 spec:
   project: bootstrap
   source:

--- a/bootstrap/templates/cluster-ca.yaml
+++ b/bootstrap/templates/cluster-ca.yaml
@@ -13,6 +13,9 @@ spec:
       valuesObject:
         cluster:
           domain: '{{ .Values.cluster.domain }}'
+        letsencrypt:
+          enabled: {{ .Values.letsencrypt.enabled }}
+          email: '{{ .Values.letsencrypt.email }}'
   destination:
     server: "https://kubernetes.default.svc"
     namespace: cert-manager

--- a/bootstrap/values.yaml
+++ b/bootstrap/values.yaml
@@ -24,3 +24,7 @@ secretStore:
 infisical:
   project: test
   path: test
+
+letsencrypt:
+  enabled: false
+  email: ""

--- a/charts/bootstrap-argo/templates/app.yaml
+++ b/charts/bootstrap-argo/templates/app.yaml
@@ -26,6 +26,9 @@ spec:
         infisical:
           project: '{{ .Values.infisical.project }}'
           path: '{{ .Values.infisical.path }}'
+        letsencrypt:
+          enabled: {{ .Values.letsencrypt.enabled }}
+          email: '{{ .Values.letsencrypt.email }}'
   destination:
     namespace: default
     server: 'https://kubernetes.default.svc'

--- a/charts/bootstrap-argo/values.yaml
+++ b/charts/bootstrap-argo/values.yaml
@@ -16,6 +16,10 @@ secretStore:
 infisical:
   project: my-project
   path: clusters/my-cluster
+letsencrypt:
+  enabled: false
+  email: ""
+
 sourceRepos:
   - 'https://kubernetes.github.io/ingress-nginx'
   - 'https://grafana.github.io/helm-charts'

--- a/charts/cert-manager-webhook-linode/.helmignore
+++ b/charts/cert-manager-webhook-linode/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/charts/cert-manager-webhook-linode/Chart.yaml
+++ b/charts/cert-manager-webhook-linode/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+appVersion: v0.4.1
+description: A Helm chart for cert-manager-webhook-linode
+name: cert-manager-webhook-linode
+version: v0.4.1

--- a/charts/cert-manager-webhook-linode/templates/_helpers.tpl
+++ b/charts/cert-manager-webhook-linode/templates/_helpers.tpl
@@ -1,0 +1,48 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "cert-manager-webhook-linode.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "cert-manager-webhook-linode.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "cert-manager-webhook-linode.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "cert-manager-webhook-linode.selfSignedIssuer" -}}
+{{ printf "%s-selfsign" (include "cert-manager-webhook-linode.fullname" .) }}
+{{- end -}}
+
+{{- define "cert-manager-webhook-linode.rootCAIssuer" -}}
+{{ printf "%s-ca" (include "cert-manager-webhook-linode.fullname" .) }}
+{{- end -}}
+
+{{- define "cert-manager-webhook-linode.rootCACertificate" -}}
+{{ printf "%s-ca" (include "cert-manager-webhook-linode.fullname" .) }}
+{{- end -}}
+
+{{- define "cert-manager-webhook-linode.servingCertificate" -}}
+{{ printf "%s-webhook-tls" (include "cert-manager-webhook-linode.fullname" .) }}
+{{- end -}}

--- a/charts/cert-manager-webhook-linode/templates/apiservice.yaml
+++ b/charts/cert-manager-webhook-linode/templates/apiservice.yaml
@@ -1,0 +1,19 @@
+apiVersion: apiregistration.k8s.io/v1
+kind: APIService
+metadata:
+  name: v1alpha1.{{ .Values.api.groupName }}
+  labels:
+    app: {{ include "cert-manager-webhook-linode.name" . }}
+    chart: {{ include "cert-manager-webhook-linode.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  annotations:
+    cert-manager.io/inject-ca-from: "{{ .Release.Namespace }}/{{ include "cert-manager-webhook-linode.servingCertificate" . }}"
+spec:
+  group: {{ .Values.api.groupName }}
+  groupPriorityMinimum: 1000
+  versionPriority: 15
+  service:
+    name: {{ include "cert-manager-webhook-linode.fullname" . }}
+    namespace: {{ .Values.certManager.namespace | quote }}
+  version: v1alpha1

--- a/charts/cert-manager-webhook-linode/templates/deployment.yaml
+++ b/charts/cert-manager-webhook-linode/templates/deployment.yaml
@@ -1,0 +1,76 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "cert-manager-webhook-linode.fullname" . }}
+  namespace: {{ .Values.certManager.namespace | quote }}
+  labels:
+    app: {{ include "cert-manager-webhook-linode.name" . }}
+    chart: {{ include "cert-manager-webhook-linode.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ include "cert-manager-webhook-linode.name" . }}
+      release: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app: {{ include "cert-manager-webhook-linode.name" . }}
+        release: {{ .Release.Name }}
+    spec:
+      serviceAccountName: {{ include "cert-manager-webhook-linode.fullname" . }}
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+            - --tls-cert-file=/tls/tls.crt
+            - --tls-private-key-file=/tls/tls.key
+{{- if .Values.deployment.logLevel }}
+            - --v={{ .Values.deployment.logLevel }}
+{{- end }}
+          env:
+            - name: GROUP_NAME
+              value: {{ .Values.api.groupName | quote }}
+            - name: POD_SECRET_NAME
+              value: {{ .Values.deployment.secretName | quote }} 
+            - name: POD_SECRET_KEY
+              value: {{ .Values.deployment.secretKey | quote }} 
+          ports:
+            - name: https
+              containerPort: 443
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              scheme: HTTPS
+              path: /healthz
+              port: https
+          readinessProbe:
+            httpGet:
+              scheme: HTTPS
+              path: /healthz
+              port: https
+          volumeMounts:
+            - name: certs
+              mountPath: /tls
+              readOnly: true
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+      volumes:
+        - name: certs
+          secret:
+            secretName: {{ include "cert-manager-webhook-linode.servingCertificate" . }}
+    {{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}

--- a/charts/cert-manager-webhook-linode/templates/pki.yaml
+++ b/charts/cert-manager-webhook-linode/templates/pki.yaml
@@ -1,0 +1,76 @@
+---
+# Create a selfsigned Issuer, in order to create a root CA certificate for
+# signing webhook serving certificates
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: {{ include "cert-manager-webhook-linode.selfSignedIssuer" . }}
+  namespace: {{ .Values.certManager.namespace | quote }}
+  labels:
+    app: {{ include "cert-manager-webhook-linode.name" . }}
+    chart: {{ include "cert-manager-webhook-linode.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  selfSigned: {}
+
+---
+
+# Generate a CA Certificate used to sign certificates for the webhook
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ include "cert-manager-webhook-linode.rootCACertificate" . }}
+  namespace: {{ .Values.certManager.namespace | quote }}
+  labels:
+    app: {{ include "cert-manager-webhook-linode.name" . }}
+    chart: {{ include "cert-manager-webhook-linode.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  secretName: {{ include "cert-manager-webhook-linode.rootCACertificate" . }}
+  duration: 43800h # 5y
+  issuerRef:
+    name: {{ include "cert-manager-webhook-linode.selfSignedIssuer" . }}
+  commonName: "ca.cert-manager-webhook-linode.cert-manager"
+  isCA: true
+
+---
+
+# Create an Issuer that uses the above generated CA certificate to issue certs
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: {{ include "cert-manager-webhook-linode.rootCAIssuer" . }}
+  namespace: {{ .Values.certManager.namespace | quote }}
+  labels:
+    app: {{ include "cert-manager-webhook-linode.name" . }}
+    chart: {{ include "cert-manager-webhook-linode.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  ca:
+    secretName: {{ include "cert-manager-webhook-linode.rootCACertificate" . }}
+
+---
+
+# Finally, generate a serving certificate for the webhook to use
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ include "cert-manager-webhook-linode.servingCertificate" . }}
+  namespace: {{ .Values.certManager.namespace | quote }}
+  labels:
+    app: {{ include "cert-manager-webhook-linode.name" . }}
+    chart: {{ include "cert-manager-webhook-linode.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  secretName: {{ include "cert-manager-webhook-linode.servingCertificate" . }}
+  duration: 8760h # 1y
+  issuerRef:
+    name: {{ include "cert-manager-webhook-linode.rootCAIssuer" . }}
+  dnsNames:
+  - {{ include "cert-manager-webhook-linode.fullname" . }}
+  - {{ include "cert-manager-webhook-linode.fullname" . }}.{{ .Values.certManager.namespace }}
+  - {{ include "cert-manager-webhook-linode.fullname" . }}.{{ .Values.certManager.namespace }}.svc

--- a/charts/cert-manager-webhook-linode/templates/rbac.yaml
+++ b/charts/cert-manager-webhook-linode/templates/rbac.yaml
@@ -1,0 +1,118 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "cert-manager-webhook-linode.fullname" . }}
+  namespace: {{ .Values.certManager.namespace | quote }}
+  labels:
+    app: {{ include "cert-manager-webhook-linode.name" . }}
+    chart: {{ include "cert-manager-webhook-linode.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+---
+# Grant the webhook permission to read the ConfigMap containing the Kubernetes
+# apiserver's requestheader-ca-certificate.
+# This ConfigMap is automatically created by the Kubernetes apiserver.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "cert-manager-webhook-linode.fullname" . }}:webhook-authentication-reader
+  namespace: kube-system
+  labels:
+    app: {{ include "cert-manager-webhook-linode.name" . }}
+    chart: {{ include "cert-manager-webhook-linode.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: extension-apiserver-authentication-reader
+subjects:
+  - apiGroup: ""
+    kind: ServiceAccount
+    name: {{ include "cert-manager-webhook-linode.fullname" . }}
+    namespace: {{ .Values.certManager.namespace | quote }}
+---
+# apiserver gets the auth-delegator role to delegate auth decisions to
+# the core apiserver
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "cert-manager-webhook-linode.fullname" . }}:auth-delegator
+  labels:
+    app: {{ include "cert-manager-webhook-linode.name" . }}
+    chart: {{ include "cert-manager-webhook-linode.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:auth-delegator
+subjects:
+  - apiGroup: ""
+    kind: ServiceAccount
+    name: {{ include "cert-manager-webhook-linode.fullname" . }}
+    namespace: {{ .Values.certManager.namespace | quote }}
+---
+# Grant cert-manager permission to validate using our apiserver
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "cert-manager-webhook-linode.fullname" . }}:domain-solver
+  labels:
+    app: {{ include "cert-manager-webhook-linode.name" . }}
+    chart: {{ include "cert-manager-webhook-linode.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+rules:
+  - apiGroups:
+      - {{ .Values.api.groupName }}
+    resources:
+      - "*"
+    verbs:
+      - "create"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "cert-manager-webhook-linode.fullname" . }}:domain-solver
+  labels:
+    app: {{ include "cert-manager-webhook-linode.name" . }}
+    chart: {{ include "cert-manager-webhook-linode.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "cert-manager-webhook-linode.fullname" . }}:domain-solver
+subjects:
+  - apiGroup: ""
+    kind: ServiceAccount
+    name: {{ .Values.certManager.serviceAccountName }}
+    namespace: {{ .Values.certManager.namespace | quote }}
+---
+# Grant the webhook permission to read the Secret containing the Linode API token
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "cert-manager-webhook-linode.fullname" . }}:secret-reader
+  namespace: {{ .Values.certManager.namespace | quote }}
+rules:
+- apiGroups: [""]
+  resources: ["secrets"]
+  resourceNames: [{{ .Values.deployment.secretName }}]
+  verbs: ["get", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "cert-manager-webhook-linode.fullname" . }}:secret-reader
+  namespace: {{ .Values.certManager.namespace | quote }}
+subjects:
+ - apiGroup: ""
+   kind: ServiceAccount
+   name: {{ include "cert-manager-webhook-linode.fullname" . }}
+   namespace: {{ .Values.certManager.namespace | quote }}
+roleRef:
+  kind: Role
+  name: {{ include "cert-manager-webhook-linode.fullname" . }}:secret-reader
+  apiGroup: rbac.authorization.k8s.io

--- a/charts/cert-manager-webhook-linode/templates/service.yaml
+++ b/charts/cert-manager-webhook-linode/templates/service.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "cert-manager-webhook-linode.fullname" . }}
+  namespace: {{ .Values.certManager.namespace | quote }}
+  labels:
+    app: {{ include "cert-manager-webhook-linode.name" . }}
+    chart: {{ include "cert-manager-webhook-linode.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: https
+      protocol: TCP
+      name: https
+  selector:
+    app: {{ include "cert-manager-webhook-linode.name" . }}
+    release: {{ .Release.Name }}

--- a/charts/cert-manager-webhook-linode/values.yaml
+++ b/charts/cert-manager-webhook-linode/values.yaml
@@ -1,0 +1,49 @@
+# The GroupName here is used to identify your company or business unit that
+# created this webhook.
+# For example, this may be "acme.mycompany.com".
+# This name will need to be referenced in each Issuer's `webhook` stanza to
+# inform cert-manager of where to send ChallengePayload resources in order to
+# solve the DNS01 challenge.
+# This group name should be **unique**, hence using your own company's domain
+# here is recommended.
+api:
+  groupName: acme.slicen.me
+
+certManager:
+  namespace: cert-manager
+  serviceAccountName: cert-manager
+
+deployment:
+  secretName: linode-credentials
+  secretKey: token
+  logLevel: 6
+
+image:
+  repository: linode/cert-manager-webhook-linode
+  tag: latest
+  pullPolicy: Always
+
+nameOverride: ""
+fullnameOverride: ""
+
+service:
+  type: ClusterIP
+  port: 443
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #  cpu: 100m
+  #  memory: 128Mi
+  # requests:
+  #  cpu: 100m
+  #  memory: 128Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}

--- a/manifests/cluster-ca/templates/cluster-issuer.yaml
+++ b/manifests/cluster-ca/templates/cluster-issuer.yaml
@@ -11,13 +11,14 @@ spec:
     privateKeySecretRef:
       name: letsencrypt-account-key
     solvers:
-      - http01:
-          ingress:
-            ingressClassName: nginx
-            ingressTemplate:
-              metadata:
-                annotations:
-                  nginx.ingress.kubernetes.io/ssl-redirect: "false"
+      - dns01:
+          webhook:
+            groupName: acme.slicen.me
+            solverName: linode
+            config:
+              apiKeySecretRef:
+                name: linode-token
+                key: LINODE_TOKEN
 {{- else }}
 ---
 apiVersion: cert-manager.io/v1

--- a/manifests/cluster-ca/templates/cluster-issuer.yaml
+++ b/manifests/cluster-ca/templates/cluster-issuer.yaml
@@ -15,10 +15,6 @@ spec:
           webhook:
             groupName: acme.slicen.me
             solverName: linode
-            config:
-              apiKeySecretRef:
-                name: linode-token
-                key: LINODE_TOKEN
 {{- else }}
 ---
 apiVersion: cert-manager.io/v1

--- a/manifests/cluster-ca/templates/cluster-issuer.yaml
+++ b/manifests/cluster-ca/templates/cluster-issuer.yaml
@@ -14,6 +14,10 @@ spec:
       - http01:
           ingress:
             ingressClassName: nginx
+            ingressTemplate:
+              metadata:
+                annotations:
+                  nginx.ingress.kubernetes.io/ssl-redirect: "false"
 {{- else }}
 ---
 apiVersion: cert-manager.io/v1

--- a/manifests/cluster-ca/templates/cluster-issuer.yaml
+++ b/manifests/cluster-ca/templates/cluster-issuer.yaml
@@ -1,3 +1,20 @@
+{{- if .Values.letsencrypt.enabled }}
+---
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: cluster-issuer
+spec:
+  acme:
+    email: {{ .Values.letsencrypt.email }}
+    server: https://acme-v02.api.letsencrypt.org/directory
+    privateKeySecretRef:
+      name: letsencrypt-account-key
+    solvers:
+      - http01:
+          ingress:
+            ingressClassName: nginx
+{{- else }}
 ---
 apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
@@ -7,3 +24,4 @@ metadata:
 spec:
   ca:
     secretName: root-ca
+{{- end }}

--- a/manifests/cluster-ca/templates/linode-token.yaml
+++ b/manifests/cluster-ca/templates/linode-token.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.letsencrypt.enabled }}
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: linode-token
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: cluster-secrets
+  target:
+    name: linode-token
+  data:
+    - secretKey: LINODE_TOKEN
+      remoteRef:
+        key: external-dns
+        property: LINODE_TOKEN
+{{- end }}

--- a/manifests/cluster-ca/templates/linode-token.yaml
+++ b/manifests/cluster-ca/templates/linode-token.yaml
@@ -9,9 +9,9 @@ spec:
     kind: ClusterSecretStore
     name: cluster-secrets
   target:
-    name: linode-token
+    name: linode-credentials
   data:
-    - secretKey: LINODE_TOKEN
+    - secretKey: token
       remoteRef:
         key: external-dns
         property: LINODE_TOKEN

--- a/manifests/cluster-ca/templates/root-ca.yaml
+++ b/manifests/cluster-ca/templates/root-ca.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.letsencrypt.enabled }}
 ---
 apiVersion: cert-manager.io/v1
 kind: Certificate
@@ -18,3 +19,4 @@ spec:
     name: root-issuer
     kind: Issuer
     group: cert-manager.io
+{{- end }}

--- a/manifests/cluster-ca/templates/root-issuer.yaml
+++ b/manifests/cluster-ca/templates/root-issuer.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.letsencrypt.enabled }}
 ---
 apiVersion: cert-manager.io/v1
 kind: Issuer
@@ -6,3 +7,4 @@ metadata:
   namespace: cert-manager
 spec:
   selfSigned: {}
+{{- end }}

--- a/manifests/cluster-ca/values.yaml
+++ b/manifests/cluster-ca/values.yaml
@@ -1,2 +1,6 @@
 cluster:
   domain: k3s-lab.local
+
+letsencrypt:
+  enabled: false
+  email: ""

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -21,6 +21,7 @@ INFISICAL_PROJECT="example-project"
 INFISICAL_PATH="/shared/argocd/bootstrap"
 DOMAIN=""
 SECRET_STORE_BACKEND="kubernetes"
+LETSENCRYPT_EMAIL=""
 
 # Constants, cannot be set via flags or environment variables
 REPO_URL=git@github.com:joerx/lab-cluster.sh.git
@@ -96,6 +97,10 @@ while [[ $# -gt 0 ]]; do
     --auto-sync)
       AUTO_SYNC="true"
       shift
+      ;;
+    --letsencrypt-email)
+      LETSENCRYPT_EMAIL="$2"
+      shift 2
       ;;
     --)
       shift
@@ -186,7 +191,9 @@ helm upgrade --install bootstrap-argo ./charts/bootstrap-argo \
   --set "autosync.enabled=$AUTO_SYNC" \
   --set "secretStore.backend=$SECRET_STORE_BACKEND" \
   --set "infisical.project=$INFISICAL_PROJECT" \
-  --set "infisical.path=$INFISICAL_PATH"
+  --set "infisical.path=$INFISICAL_PATH" \
+  --set "letsencrypt.enabled=${LETSENCRYPT_EMAIL:+true}" \
+  --set "letsencrypt.email=$LETSENCRYPT_EMAIL"
 
 # Installs the secret with the initial credentials (infisical backend) or seeds the
 # local-secrets namespace (kubernetes backend). Everything after that is managed by


### PR DESCRIPTION
This PR adds integration of LetsEncrypt for certificate management instead of using a self-signed root CA. This currently requires a Linode domain to do the ACME challenge. To provide support for Linode domains, https://github.com/linode/cert-manager-webhook-linode is installed as an additional bootstrap application. The chart for this webhook had to be vendored since the chart release is only available as a tarball which is not supported by ArgoCD
