### PR TITLE
Replace ExternalSecret with helm-managed ghcr pull secret

### DIFF
--- a/charts/bootstrap-argo/templates/ghcr-pull-secret.yaml
+++ b/charts/bootstrap-argo/templates/ghcr-pull-secret.yaml
@@ -1,27 +1,10 @@
-apiVersion: external-secrets.io/v1
-kind: ExternalSecret
+{{- if .Values.ghcr.username }}
+apiVersion: v1
+kind: Secret
 metadata:
   name: {{ .Values.ghcr.pullSecretName }}
   namespace: argocd
-spec:
-  refreshInterval: 1h
-  secretStoreRef:
-    name: cluster-secrets
-    kind: ClusterSecretStore
-  target:
-    name: {{ .Values.ghcr.pullSecretName }}
-    template:
-      type: kubernetes.io/dockerconfigjson
-      data:
-        # https://www.codestudy.net/blog/how-an-helm-chart-have-an-attribute-with-value-contain/
-        .dockerconfigjson: |
-          {"auths":{"ghcr.io":{"username":"{{ "{{" }} .username {{ "}}" }}","password":"{{ "{{" }} .token {{ "}}" }}","auth":"{{ "{{" }} printf "%s:%s" .username .token | b64enc {{ "}}" }}"}}}
-  data:
-    - secretKey: username
-      remoteRef:
-        key: {{ .Values.ghcr.pullSecretName }}
-        property: username
-    - secretKey: token
-      remoteRef:
-        key: {{ .Values.ghcr.pullSecretName }}
-        property: password
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: {{ dict "auths" (dict "ghcr.io" (dict "username" .Values.ghcr.username "password" .Values.ghcr.token "auth" (printf "%s:%s" .Values.ghcr.username .Values.ghcr.token | b64enc))) | toJson | b64enc }}
+{{- end }}

--- a/charts/bootstrap-argo/values.yaml
+++ b/charts/bootstrap-argo/values.yaml
@@ -30,3 +30,5 @@ sourceRepos:
 
 ghcr:
   pullSecretName: ghcr-pull-secret
+  username: ""
+  token: ""

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -22,6 +22,8 @@ INFISICAL_PATH="/shared/argocd/bootstrap"
 DOMAIN=""
 SECRET_STORE_BACKEND="kubernetes"
 LETSENCRYPT_ENABLED=false
+GHCR_USERNAME=""
+GHCR_TOKEN=""
 
 # Constants, cannot be set via flags or environment variables
 REPO_URL=git@github.com:joerx/lab-cluster.sh.git
@@ -102,6 +104,14 @@ while [[ $# -gt 0 ]]; do
       LETSENCRYPT_ENABLED="true"
       shift
       ;;
+    --ghcr-username)
+      GHCR_USERNAME="$2"
+      shift 2
+      ;;
+    --ghcr-token)
+      GHCR_TOKEN="$2"
+      shift 2
+      ;;
     --)
       shift
       break
@@ -122,6 +132,8 @@ done
 
 NAME=${NAME:-"k3s-lab-$(hostname)"}
 DOMAIN=${DOMAIN:-"$NAME.local"}
+GHCR_USERNAME=${GHCR_USERNAME:-$(git config user.name 2>/dev/null || true)}
+GHCR_TOKEN=${GHCR_TOKEN:-${GITHUB_TOKEN:-}}
 
 log "Bootstrapping cluster '$NAME'"
 log "- Repo URL: $REPO_URL"
@@ -192,7 +204,9 @@ helm upgrade --install bootstrap-argo ./charts/bootstrap-argo \
   --set "secretStore.backend=$SECRET_STORE_BACKEND" \
   --set "infisical.project=$INFISICAL_PROJECT" \
   --set "infisical.path=$INFISICAL_PATH" \
-  --set "letsencrypt.enabled=$LETSENCRYPT_ENABLED"
+  --set "letsencrypt.enabled=$LETSENCRYPT_ENABLED" \
+  --set "ghcr.username=${GHCR_USERNAME:-}" \
+  --set "ghcr.token=${GHCR_TOKEN:-}"
 
 # Installs the secret with the initial credentials (infisical backend) or seeds the
 # local-secrets namespace (kubernetes backend). Everything after that is managed by


### PR DESCRIPTION
## Summary

- Replaces the `ExternalSecret` for the GHCR pull secret with a plain `kubernetes.io/dockerconfigjson` Secret rendered directly by Helm
- Fixes a bootstrap ordering problem: the `ExternalSecret` depends on ESO and the `ClusterSecretStore`, which are deployed by ArgoCD — so they're not available when `bootstrap-argo` is first applied
- Credentials default to `git config user.name` and `$GITHUB_TOKEN`, and can be overridden via `--ghcr-username` / `--ghcr-token` flags or the `.env` file
- The secret is skipped entirely if no username is provided

## Test plan

- [ ] Run `bootstrap.sh` with `GITHUB_TOKEN` set and verify `ghcr-pull-secret` is created in the `argocd` namespace
- [ ] Run `bootstrap.sh` without GHCR credentials and verify no secret is created (no error)
- [ ] Run `bootstrap.sh` with `--ghcr-username` / `--ghcr-token` flags and verify they take precedence

🤖 Generated with [Claude Code](https://claude.com/claude-code)