### PR TITLE
Add Authelia as in-cluster identity provider

### DIFF
--- a/bootstrap/templates/authelia.yaml
+++ b/bootstrap/templates/authelia.yaml
@@ -76,8 +76,7 @@ spec:
             access_control:
               default_policy: one_factor
           persistence:
-            enabled: true
-            size: 100Mi
+            enabled: false
     - repoURL: '{{ .Values.source.repoURL }}'
       targetRevision: '{{ .Values.source.targetRevision }}'
       path: manifests/authelia

--- a/manifests/authelia/external-secret.yaml
+++ b/manifests/authelia/external-secret.yaml
@@ -12,4 +12,4 @@ spec:
     - secretKey: users_database.yml
       remoteRef:
         key: authelia-users
-        property: users_database.yml
+        property: users_database


### PR DESCRIPTION
## Summary

- Adds Authelia as an optional in-cluster IdP, deployed as an ArgoCD Application via the bootstrap chart
- Users database is injected as a Kubernetes secret (sourced from Infisical or a local secret for dev) rather than stored in git
- Bootstrap script gains an `--authelia` flag that hashes the admin password and seeds the users secret at install time
- SQLite storage runs on ephemeral pod storage (no PVC) — acceptable since no TOTP/WebAuthn is used

## Changes

- `bootstrap/templates/authelia.yaml` — new ArgoCD Application for Authelia (conditional on `authelia.enabled`); file-based auth, nginx ingress, no persistence
- `manifests/authelia/external-secret.yaml` — ExternalSecret pulling the users database from `ClusterSecretStore/cluster-secrets`
- `charts/bootstrap-argo` — threads `authelia.enabled` / `authelia.chartVersion` through to app values; adds `https://charts.authelia.com` to project sourceRepos
- `charts/bootstrap-secrets` — adds `localSecrets.authelia.usersDatabase` for kubernetes-backend installs; creates `local-secrets` namespace and secret when set
- `scripts/bootstrap.sh` — `--authelia` flag; hashes password with `openssl passwd -6`, writes temp values file, cleans up on exit; warns when Infisical backend is used (manual secret upload required)
- `.env.example` — adds `AUTHELIA_ADMIN_PASSWORD`

## Test plan

- [x] `bootstrap.sh --authelia` with `--secret-store kubernetes` provisions the users secret and Authelia comes up healthy
- [x] Authelia ingress is reachable at `https://auth.<domain>`
- [x] Pod restart does not cause extended downtime (no PVC re-mount delay)
- [x] Apps protected with `nginx.ingress.kubernetes.io/auth-url` redirect unauthenticated requests to Authelia
- [x] Disabling `--authelia` (default) leaves no Authelia resources deployed

🤖 Generated with [Claude Code](https://claude.com/claude-code)